### PR TITLE
set ownership in the release bundle to avoid unowned files when installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ release: all
 	cp bin/lldpd rel/usr/local/bin
 	cp lldpd.service rel/etc/systemd/system
 	cd rel \
-	&& tar -cvzf go-lldpd.tgz usr/local/bin/lldpd etc/systemd/system/lldpd.service \
+	&& tar --owner=root --group=root -cvzf go-lldpd.tgz usr/local/bin/lldpd etc/systemd/system/lldpd.service \
 	&& mv go-lldpd.tgz .. \
 	&& cd -


### PR DESCRIPTION
Files of the tarball are owned by the build user. This leads to unowned files in the metal-images:

-rwxr-xr-x 1 1001 123 3867800 Feb 23 13:12 /usr/local/bin/lldpd
-rw-r--r-- 1 1001 123 173 Feb 23 13:12 /etc/systemd/system/lldpd.service

This PR sets owner and group on tar creation. 