### PR TITLE
Handle context done

### DIFF
--- a/pkg/lldp/client.go
+++ b/pkg/lldp/client.go
@@ -90,7 +90,6 @@ func (l *Client) Start(log *slog.Logger, resultChan chan<- DiscoveryResult) erro
 					SysName:        info.SysName,
 					SysDescription: info.SysDescription,
 				}
-				// log.Debugw("received LinkLayerDiscoveryInfo", "result", dr)
 				resultChan <- dr
 			}
 		case <-l.ctx.Done():


### PR DESCRIPTION
After the context is done, the LLDP discovery should terminate immediately. However, it unnecessarily waits for the next EOF error to do so.